### PR TITLE
Add Categories to message improve UI and fix deprecations

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -279,9 +279,9 @@ public class BuildFailureScanner extends RunListener<Run> {
      * @param buildNum - Build object
      * @param buildUrl - Full URL of build
      * @param scanLog - PrintStream for the build log
-     * @return boolean true if message successfully created, false otherwise
+     * @return String message if message successfully created, null otherwise
      */
-    public static boolean createSlackMessage(List<FoundFailureCause> foundCauseList,
+    public static String createSlackMessage(List<FoundFailureCause> foundCauseList,
             boolean notifySlackOfAllFailures, List<String> slackFailureCauseCategories,
             String buildName, String buildNum, String buildUrl, PrintStream scanLog) {
         boolean notifySlackOfFailure = false;
@@ -289,23 +289,31 @@ public class BuildFailureScanner extends RunListener<Run> {
 
         /* Check if one of the failure causes for the build matches those specified in plugin's slack settings. */
         for (FoundFailureCause foundCause : foundCauseList) {
-            if (!notifySlackOfAllFailures) {
+            if(notifySlackOfAllFailures){
+                /* Create list for slack message with failure causes from build */
+                if (bufBuildFailCause.length() != 0) {
+                    bufBuildFailCause.append("\n");
+                }
+                bufBuildFailCause.append("*Failure Name:* ");
+                bufBuildFailCause.append(foundCause.getName());
+                bufBuildFailCause.append("\n");
+                bufBuildFailCause.append("*Failure Categories:* ");
+                bufBuildFailCause.append(foundCause.getCategories());
+            } else {
+                /* Only notify the selected categories even if more occur*/
                 List<String> categories = foundCause.getCategories();
                 if (categories != null) {
                     for (String category : categories) {
                         if (failureCategoryMatches(category, slackFailureCauseCategories)) {
                             notifySlackOfFailure = true;
-                            break;
+                            bufBuildFailCause.append("*Failure Name:* ");
+                            bufBuildFailCause.append(foundCause.getName());
+                            bufBuildFailCause.append("\n");
+                            bufBuildFailCause.append("*Failure Categories:* ");
+                            bufBuildFailCause.append(foundCause.getCategories());
                         }
                     }
                 }
-            }
-            /* Create list for slack message with failure causes from build */
-            if (bufBuildFailCause.length() == 0) {
-                bufBuildFailCause.append(foundCause.getName());
-            } else {
-                bufBuildFailCause.append("\n");
-                bufBuildFailCause.append(foundCause.getName());
             }
         }
 
@@ -314,14 +322,14 @@ public class BuildFailureScanner extends RunListener<Run> {
             SlackMessageProvider slack = new SlackMessageProvider();
 
             StringBuilder s = new StringBuilder("Job *\"" + buildName + "\"*");
-            s.append(" build *#" + buildNum + "* FAILED due to following failure causes: \n```");
-            s.append(bufBuildFailCause.toString() + "```\nSee ");
+            s.append(" build *#" + buildNum + "* FAILED due to following failure causes: \n");
+            s.append(bufBuildFailCause.toString() + "\nSee ");
             s.append(buildUrl + " for details.");
 
             slack.postToSlack(s.toString(), scanLog);
-            return true;
+            return s.toString();
         }
-        return false;
+        return null;
     }
 
     /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -289,7 +289,7 @@ public class BuildFailureScanner extends RunListener<Run> {
 
         /* Check if one of the failure causes for the build matches those specified in plugin's slack settings. */
         for (FoundFailureCause foundCause : foundCauseList) {
-            if(notifySlackOfAllFailures){
+            if (notifySlackOfAllFailures) {
                 /* Create list for slack message with failure causes from build */
                 if (bufBuildFailCause.length() != 0) {
                     bufBuildFailCause.append("\n");

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -625,7 +625,7 @@ public class PluginImpl extends GlobalConfiguration {
      * @param slackFailureCategories - Space seperated list of failure cause categories.
      */
     @DataBoundSetter
-    public void setslackFailureCategories(String slackFailureCategories) {
+    public void setSlackFailureCategories(String slackFailureCategories) {
         this.slackFailureCategories = slackFailureCategories;
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/Statistics.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/Statistics.java
@@ -198,7 +198,7 @@ public class Statistics {
     }
 
         /**
-         * @deprecated, kept for backwards compatibility.
+         * deprecated, kept for backwards compatibility.
          * @param projectName the project name.
          * @param buildNumber the build number.
          * @param startingTime the starting time.

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
@@ -335,7 +335,7 @@ public class BuildFailureScannerHudsonTest {
         String result = BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
                 slackFailureCauseCategories, "Sandbox", "#1",
                 Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
-        String expected= String.join("\n",
+        String expected = String.join("\n",
                 "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
                 "*Failure Name:* Some Fail Cause",
                 "*Failure Categories:* []",
@@ -364,7 +364,7 @@ public class BuildFailureScannerHudsonTest {
         String result = BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
                 slackFailureCauseCategories, "Sandbox", "#1",
                 Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
-        String expected= String.join("\n",
+        String expected = String.join("\n",
                 "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
                 "*Failure Name:* Some Fail Cause",
                 "*Failure Categories:* []",
@@ -393,7 +393,7 @@ public class BuildFailureScannerHudsonTest {
         String result = BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
                 slackFailureCauseCategories, "Sandbox", "#1",
                 Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
-        String expected= String.join("\n",
+        String expected = String.join("\n",
                 "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
                 "*Failure Name:* Some Fail Cause",
                 "*Failure Categories:* [env]",
@@ -425,7 +425,7 @@ public class BuildFailureScannerHudsonTest {
                 slackFailureCauseCategories, "Sandbox", "#1",
                 Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
 
-        String expected= String.join("\n",
+        String expected = String.join("\n",
                 "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
                 "*Failure Name:* Some Fail Cause",
                 "*Failure Categories:* [env]",
@@ -439,7 +439,7 @@ public class BuildFailureScannerHudsonTest {
 
     /**
      * Test to ensure multiple failure categories can be specified, and if not all the categories
-     * match a new Slack message should be created with only the selected category
+     * match a new Slack message should be created with only the selected category.
      * @throws Exception if so.
      */
     @Test
@@ -459,7 +459,7 @@ public class BuildFailureScannerHudsonTest {
                 slackFailureCauseCategories, "Sandbox", "#1",
                 Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
 
-        String expected= String.join("\n",
+        String expected = String.join("\n",
                 "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
                 "*Failure Name:* Some Fail Cause",
                 "*Failure Categories:* [env]",
@@ -536,7 +536,7 @@ public class BuildFailureScannerHudsonTest {
         String result =  BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
                 slackFailureCauseCategories, "Sandbox", "#1",
                 Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
-        String expected= String.join("\n",
+        String expected = String.join("\n",
                 "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
                 "*Failure Name:* Some Fail Cause",
                 "*Failure Categories:* [env]",

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
@@ -49,9 +49,9 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.model.listeners.RunListener;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.tasks.junit.JUnitResultArchiver;
 import jenkins.model.Jenkins;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -73,7 +73,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertFalse;
@@ -123,7 +122,7 @@ public class BuildFailureScannerHudsonTest {
 
         FailureCause failureCause = configureCauseAndIndication();
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
 
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
@@ -169,7 +168,7 @@ public class BuildFailureScannerHudsonTest {
 
         FreeStyleProject project = createProject("Generic Error\nUnknown Error");
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
 
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
@@ -199,7 +198,7 @@ public class BuildFailureScannerHudsonTest {
 
         FreeStyleProject project = createProject("Generic Error\nSpecific Error");
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
 
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
@@ -222,7 +221,7 @@ public class BuildFailureScannerHudsonTest {
 
         FailureCause failureCause = configureCauseAndIndication(new MultilineBuildLogIndication(MULTILINE_REGEX));
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
 
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
@@ -267,7 +266,7 @@ public class BuildFailureScannerHudsonTest {
         final String otherDescription = "Other description";
         FailureCause failureCause2 = configureCauseAndIndication("Other cause", otherDescription, indication);
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
 
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
@@ -318,6 +317,64 @@ public class BuildFailureScannerHudsonTest {
     }
 
     /**
+     * Test to ensure no failure category can be specified, and if all build failures
+     * are to be reported, a new Slack message should be created.
+     * @throws Exception if so.
+     */
+    @Test
+    public void testNoCategoryALLSlackMessage() throws Exception {
+        PluginImpl.getInstance().setSlackNotifEnabled(true);
+        FailureCause testFailureCause = new FailureCause("Some Fail Cause", "Some Description", "", "");
+        FoundFailureCause test1 = new FoundFailureCause(testFailureCause);
+        List<FoundFailureCause> foundCauseList = Arrays.asList(test1);
+
+        boolean notifySlackOfAllFailures = true;
+        List<String> slackFailureCauseCategories = Arrays.asList("ALL");
+        PrintStream buildLog = null;
+
+        String result = BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
+                slackFailureCauseCategories, "Sandbox", "#1",
+                Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
+        String expected= String.join("\n",
+                "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
+                "*Failure Name:* Some Fail Cause",
+                "*Failure Categories:* []",
+                String.format("See %sjob/test0/1/ for details.", this.jenkins.getURL())
+        );
+
+        assertEquals(expected, result);
+    }
+
+    /**
+     * Test to ensure no failure category can be specified,
+     * are to be reported, a new Slack message should be created.
+     * @throws Exception if so.
+     */
+    @Test
+    public void testNoCategorySlackMessage() throws Exception {
+        PluginImpl.getInstance().setSlackNotifEnabled(true);
+        FailureCause testFailureCause = new FailureCause("Some Fail Cause", "Some Description", "", "");
+        FoundFailureCause test1 = new FoundFailureCause(testFailureCause);
+        List<FoundFailureCause> foundCauseList = Arrays.asList(test1);
+
+        boolean notifySlackOfAllFailures = true;
+        List<String> slackFailureCauseCategories = Arrays.asList("");
+        PrintStream buildLog = null;
+
+        String result = BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
+                slackFailureCauseCategories, "Sandbox", "#1",
+                Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
+        String expected= String.join("\n",
+                "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
+                "*Failure Name:* Some Fail Cause",
+                "*Failure Categories:* []",
+                String.format("See %sjob/test0/1/ for details.", this.jenkins.getURL())
+        );
+
+        assertEquals(expected, result);
+    }
+
+    /**
      * Test to ensure one failure category can be specified, and if all build failures
      * are to be reported, a new Slack message should be created.
      * @throws Exception if so.
@@ -333,11 +390,17 @@ public class BuildFailureScannerHudsonTest {
         List<String> slackFailureCauseCategories = Arrays.asList("ALL");
         PrintStream buildLog = null;
 
-        boolean result = BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
+        String result = BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
                 slackFailureCauseCategories, "Sandbox", "#1",
-                Jenkins.getInstance().getRootUrl() + "\"job/test0/1/", buildLog);
+                Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
+        String expected= String.join("\n",
+                "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
+                "*Failure Name:* Some Fail Cause",
+                "*Failure Categories:* [env]",
+                String.format("See %sjob/test0/1/ for details.", this.jenkins.getURL())
+        );
 
-        assertEquals(true, result);
+        assertEquals(expected, result);
     }
 
     /**
@@ -350,7 +413,7 @@ public class BuildFailureScannerHudsonTest {
         PluginImpl.getInstance().setSlackNotifEnabled(true);
         FailureCause testFailureCause = new FailureCause("Some Fail Cause", "Some Description", "", "env");
         FoundFailureCause testFailureCause1 = new FoundFailureCause(testFailureCause);
-        testFailureCause = new FailureCause("Some Fail Cause", "Some Description", "", "git");
+        testFailureCause = new FailureCause("Some Fail Cause git", "Some Description git", "", "git");
         FoundFailureCause testFailureCause2 = new FoundFailureCause(testFailureCause);
         List<FoundFailureCause> foundCauseList = Arrays.asList(testFailureCause1, testFailureCause2);
 
@@ -358,11 +421,52 @@ public class BuildFailureScannerHudsonTest {
         List<String> slackFailureCauseCategories = Arrays.asList("ALL");
         PrintStream buildLog = null;
 
-        boolean result =  BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
+        String result =  BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
                 slackFailureCauseCategories, "Sandbox", "#1",
                 Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
 
-        assertEquals(true, result);
+        String expected= String.join("\n",
+                "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
+                "*Failure Name:* Some Fail Cause",
+                "*Failure Categories:* [env]",
+                "*Failure Name:* Some Fail Cause git",
+                "*Failure Categories:* [git]",
+                String.format("See %sjob/test0/1/ for details.", this.jenkins.getURL())
+        );
+
+        assertEquals(expected, result);
+    }
+
+    /**
+     * Test to ensure multiple failure categories can be specified, and if not all the categories
+     * match a new Slack message should be created with only the selected category
+     * @throws Exception if so.
+     */
+    @Test
+    public void testMultiCategoryFailureSlackMessageOnlySelected() throws Exception {
+        PluginImpl.getInstance().setSlackNotifEnabled(true);
+        FailureCause testFailureCause = new FailureCause("Some Fail Cause", "Some Description", "", "env");
+        FoundFailureCause testFailureCause1 = new FoundFailureCause(testFailureCause);
+        testFailureCause = new FailureCause("Some Fail Cause git", "Some Description", "", "git");
+        FoundFailureCause testFailureCause2 = new FoundFailureCause(testFailureCause);
+        List<FoundFailureCause> foundCauseList = Arrays.asList(testFailureCause1, testFailureCause2);
+
+        boolean notifySlackOfAllFailures = false;
+        List<String> slackFailureCauseCategories = Arrays.asList("env");
+        PrintStream buildLog = null;
+
+        String result =  BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
+                slackFailureCauseCategories, "Sandbox", "#1",
+                Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
+
+        String expected= String.join("\n",
+                "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
+                "*Failure Name:* Some Fail Cause",
+                "*Failure Categories:* [env]",
+                String.format("See %sjob/test0/1/ for details.", this.jenkins.getURL())
+        );
+
+        assertEquals(expected, result);
     }
 
     /**
@@ -381,11 +485,11 @@ public class BuildFailureScannerHudsonTest {
         List<String> slackFailureCauseCategories = Arrays.asList("git");
         PrintStream buildLog = null;
 
-        boolean result =  BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
+        String result =  BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
                 slackFailureCauseCategories, "Sandbox", "#1",
                 Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
 
-        assertEquals(false, result);
+        assertNull(result);
     }
 
     /**
@@ -406,11 +510,11 @@ public class BuildFailureScannerHudsonTest {
         List<String> slackFailureCauseCategories = Arrays.asList("git");
         PrintStream buildLog = null;
 
-        boolean result =  BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
+        String result =  BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
                 slackFailureCauseCategories, "Sandbox", "#1",
                 Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
 
-        assertEquals(false, result);
+        assertNull(result);
     }
 
     /**
@@ -429,11 +533,16 @@ public class BuildFailureScannerHudsonTest {
         List<String> slackFailureCauseCategories = Arrays.asList("env");
         PrintStream buildLog = null;
 
-        boolean result =  BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
+        String result =  BuildFailureScanner.createSlackMessage(foundCauseList, notifySlackOfAllFailures,
                 slackFailureCauseCategories, "Sandbox", "#1",
-                Jenkins.getInstance().getRootUrl() + "\"job/test0/1/", buildLog);
-
-        assertEquals(true, result);
+                Jenkins.getInstance().getRootUrl() + "job/test0/1/", buildLog);
+        String expected= String.join("\n",
+                "Job *\"Sandbox\"* build *##1* FAILED due to following failure causes: ",
+                "*Failure Name:* Some Fail Cause",
+                "*Failure Categories:* [env]",
+                String.format("See %sjob/test0/1/ for details.", this.jenkins.getURL())
+        );
+        assertEquals(expected, result);
     }
 
     /**
@@ -449,7 +558,7 @@ public class BuildFailureScannerHudsonTest {
 
         configureCauseAndIndication();
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
 
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
@@ -479,7 +588,7 @@ public class BuildFailureScannerHudsonTest {
 
         configureCauseAndIndication(new BuildLogIndication(".*something completely different.*"));
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
         FailureCauseBuildAction action = build.getAction(FailureCauseBuildAction.class);
@@ -498,7 +607,7 @@ public class BuildFailureScannerHudsonTest {
 
         configureCauseAndIndication(new MultilineBuildLogIndication(".*something completely different.*"));
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
         FailureCauseBuildAction action = build.getAction(FailureCauseBuildAction.class);
@@ -518,7 +627,7 @@ public class BuildFailureScannerHudsonTest {
 
         configureCauseAndIndication(new BuildLogIndication(".*something completely different.*"));
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
         FailureCauseBuildAction action = build.getAction(FailureCauseBuildAction.class);
@@ -542,7 +651,7 @@ public class BuildFailureScannerHudsonTest {
         project.getBuildersList().add(new PrintToLogBuilder(BUILD_LOG));
         configureCauseAndIndication();
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.SUCCESS, build);
         FailureCauseBuildAction action = build.getAction(FailureCauseBuildAction.class);
@@ -559,7 +668,7 @@ public class BuildFailureScannerHudsonTest {
         PluginImpl.getInstance().setGlobalEnabled(false);
         FreeStyleProject project = createProject();
         configureCauseAndIndication();
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
         FailureCauseBuildAction action = build.getAction(FailureCauseBuildAction.class);
@@ -576,7 +685,7 @@ public class BuildFailureScannerHudsonTest {
         PluginImpl.getInstance().setMaxLogSize(1);
         FreeStyleProject project = createProject(createHugeString(1024 * 1024) + BUILD_LOG);
         configureCauseAndIndication();
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
         FailureCauseBuildAction action = build.getAction(FailureCauseBuildAction.class);
@@ -593,7 +702,7 @@ public class BuildFailureScannerHudsonTest {
         PluginImpl.getInstance().setMaxLogSize(2);
         FreeStyleProject project = createProject(createHugeString(1024 * 1024) + BUILD_LOG);
         configureCauseAndIndication();
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
         FailureCauseBuildAction action = build.getAction(FailureCauseBuildAction.class);
@@ -628,7 +737,7 @@ public class BuildFailureScannerHudsonTest {
         FreeStyleProject project = createProject();
         project.addProperty(new ScannerJobProperty(true));
         configureCauseAndIndication();
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
         FailureCauseBuildAction action = build.getAction(FailureCauseBuildAction.class);
@@ -664,7 +773,7 @@ public class BuildFailureScannerHudsonTest {
         }).when(base).saveStatistics(Matchers.<Statistics>any());
         Whitebox.setInternalState(PluginImpl.getInstance(), KnowledgeBase.class, base);
         FreeStyleProject project = createProject();
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
         long time = System.currentTimeMillis();
@@ -726,7 +835,7 @@ public class BuildFailureScannerHudsonTest {
 
         project.getPublishersList().add(new JUnitResultArchiver("junit.xml", false, null));
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.UNSTABLE, build);
 
@@ -768,7 +877,7 @@ public class BuildFailureScannerHudsonTest {
 
         project.getPublishersList().add(new JUnitResultArchiver("junit.xml", false, null));
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.UNSTABLE, build);
 
@@ -805,7 +914,7 @@ public class BuildFailureScannerHudsonTest {
 
         project.getPublishersList().add(new JUnitResultArchiver("junit.xml", false, null));
 
-        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.UNSTABLE, build);
 

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseMatrixAggregatorTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseMatrixAggregatorTest.java
@@ -32,10 +32,10 @@ import hudson.matrix.MatrixProject;
 import hudson.model.Action;
 import hudson.model.Cause;
 import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.MockBuilder;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -48,7 +48,6 @@ import static org.junit.Assert.assertNull;
 /**
  * Tests for the FailureCauseMatrixAggregator.
  * @author Tomas Westling &lt;thomas.westling@sonyericsson.com&gt;
- * @throws Exception if so.
  */
 public class FailureCauseMatrixAggregatorTest {
     /**
@@ -70,7 +69,7 @@ public class FailureCauseMatrixAggregatorTest {
         Axis axis = new Axis("Axel", "Foley", "Rose");
         matrix.setAxes(new AxisList(axis));
         matrix.getBuildersList().add(new MockBuilder(Result.FAILURE));
-        Future<MatrixBuild> future = matrix.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<MatrixBuild> future = matrix.scheduleBuild2(0, new Cause.UserIdCause());
         MatrixBuild build = future.get(10, TimeUnit.SECONDS);
         FailureCauseMatrixBuildAction matrixAction = build.getAction(FailureCauseMatrixBuildAction.class);
         assertNotNull(matrixAction);
@@ -87,7 +86,7 @@ public class FailureCauseMatrixAggregatorTest {
         MatrixProject matrix = jenkins.createMatrixProject();
         Axis axis = new Axis("Axel", "Foley", "Rose");
         matrix.setAxes(new AxisList(axis));
-        Future<MatrixBuild> future = matrix.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<MatrixBuild> future = matrix.scheduleBuild2(0, new Cause.UserIdCause());
         MatrixBuild build = future.get(10, TimeUnit.SECONDS);
         Action matrixAction = build.getAction(FailureCauseMatrixBuildAction.class);
         assertNull(matrixAction);
@@ -105,7 +104,7 @@ public class FailureCauseMatrixAggregatorTest {
         Axis axis = new Axis("Axel", "Foley", "Rose");
         matrix.setAxes(new AxisList(axis));
         matrix.getBuildersList().add(new MockBuilder(Result.ABORTED));
-        Future<MatrixBuild> future = matrix.scheduleBuild2(0, new Cause.UserIdCause());
+        QueueTaskFuture<MatrixBuild> future = matrix.scheduleBuild2(0, new Cause.UserIdCause());
         MatrixBuild build = future.get(10, TimeUnit.SECONDS);
         FailureCauseMatrixBuildAction matrixAction = build.getAction(FailureCauseMatrixBuildAction.class);
         assertNull(matrixAction);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseWorkFlowTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseWorkFlowTest.java
@@ -25,6 +25,7 @@ package com.sonyericsson.jenkins.plugins.bfa;
 
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
 import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -32,7 +33,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import java.util.concurrent.Future;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
@@ -43,7 +43,6 @@ import static org.junit.Assert.assertNull;
 /**
  * Tests for WorkflowJobs.
  * @author Tomas Westling &lt;tomas.westling@sonymobile.com&gt;
- * @throws Exception if so.
  */
 public class FailureCauseWorkFlowTest {
     /**
@@ -62,7 +61,7 @@ public class FailureCauseWorkFlowTest {
     public void testWorkflowFailureCauseBuildAction() throws Exception {
         WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "proj");
         proj.setDefinition(new CpsFlowDefinition("error()"));
-        Future<WorkflowRun> f = proj.scheduleBuild2(0);
+        QueueTaskFuture<WorkflowRun> f = proj.scheduleBuild2(0);
         assertThat("build was actually scheduled", f, Matchers.notNullValue());
         WorkflowRun run = j.assertBuildStatus(Result.FAILURE, f.get());
         FailureCauseBuildAction action = run.getAction(FailureCauseBuildAction.class);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 /**
  * Tests for the GerritMessageProviderExtensionTest.
  * @author Alexander Akbashev mr.akbashev@gmail.com
- * @throws Exception if so.
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({PluginImpl.class, Jenkins.class })

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/SlackMessageProviderTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/SlackMessageProviderTest.java
@@ -17,7 +17,6 @@ import org.apache.http.ssl.SSLInitializationException;
 /**
  * Tests for the SlackMessageProvider class.
  * @author Johan Cornelissen &lt;j.cornelissen@queensu.ca&gt;
- * @throws Exception if so.
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({PluginImpl.class, SlackNotifier.class, Jenkins.class})

--- a/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-local-expected.yml
+++ b/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-local-expected.yml
@@ -7,6 +7,7 @@ maxLogSize: 10
 noCausesEnabled: true
 noCausesMessage: "No problems were identified. Please contribute  causes to help others"
 nrOfScanThreads: 6
+slackFailureCategories: "ALL"
 slackNotifEnabled: false
 sodVariables:
   maximumSodWorkerThreads: 4

--- a/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-mongo-expected.yml
+++ b/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-mongo-expected.yml
@@ -15,6 +15,7 @@ maxLogSize: 10
 noCausesEnabled: true
 noCausesMessage: "No problems were identified. Please contribute  causes to help others"
 nrOfScanThreads: 6
+slackFailureCategories: "ALL"
 slackNotifEnabled: false
 sodVariables:
   maximumSodWorkerThreads: 4


### PR DESCRIPTION
Add Failure Categories to Slack message.
Improve UI.
Fix a case where you end up getting information abotu two failing cases when you are only looking to get messages for one.
Remove deprecated 
java.util.concurrent.Future;
in favor of
hudson.model.queue.QueueTaskFuture;

Improve slack Message unit tests
![Screen Shot 2020-06-10 at 3 48 00 PM](https://user-images.githubusercontent.com/5922430/84326654-502c0c80-ab32-11ea-9ab0-88b502eea645.png)
